### PR TITLE
[feature:] add not operator, bool literals, variable reassignment, while loop

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -40,7 +40,7 @@
  
 %token <int>                    LBRACE 
 %token                          EOL LPAREN RPAREN LBRACKET RBRACKET RBRACE COLON SEMICOLON COMMA DOT ASSIGN
-%token                          LET FUNCTION FOR RETURN IF ELSE ELIF
+%token                          LET FUNCTION FOR WHILE RETURN IF ELSE ELIF
 %token                          TRUE FALSE
 %token                          KW_INT KW_FLOAT KW_STRING KW_BOOL
 %token <std::string>            LIT_INT LIT_FLOAT LIT_STR 
@@ -54,6 +54,7 @@
 %nterm <ast::ElifList*>                         elif_list
 %nterm <std::optional<ast::BlockStmt*>>        opt_else
 %nterm <ast::IfStmt*>                           if_stmt
+%nterm <ast::WhileStmt*>                        while_stmt
 %nterm <std::string>                            type_name
 %nterm <std::pair<std::string, std::string>>    typed_param
 %nterm <std::vector<std::pair<std::string, std::string>>*>  typed_param_list
@@ -114,11 +115,19 @@ opt_return_type : %empty                            { $$ = std::nullopt; }
 
 stmt    : EOL                                       { ; }
         | expr SEMICOLON                            { $$ = new ast::ExprStmt(@$, $1); }        
+        | Ident ASSIGN expr SEMICOLON               { $$ = new ast::ExprStmt(@$, new ast::AssignExpr(@$, $1, $3)); }
         | block_stmt                                { $$ = $1; }
         | if_stmt                                   { $$ = $1; }
+        | while_stmt                                { $$ = $1; }
         | RETURN expr SEMICOLON                     { $$ = new ast::ReturnStmt(@$, $2); }
         | error EOL                                 { yyerrok; }
-        ;       
+        ;
+
+// TODO: for loop: for Ident in expr block_stmt (requires iterator/range support)
+// TODO: break / continue statements inside while loops
+
+while_stmt : WHILE expr block_stmt               { $$ = new ast::WhileStmt(@$, $2, $3); }
+           ;
 
 expr_seq : %empty                                   { $$ = new ast::ExprSeq(); }    
         | expr                                      { $$ = new ast::ExprSeq(); $$->append($1); }      
@@ -127,7 +136,10 @@ expr_seq : %empty                                   { $$ = new ast::ExprSeq(); }
 expr    : LIT_INT                                   { $$ = new ast::IntLitExpr(@$, $1);}
         | LIT_FLOAT                                 { $$ = new ast::FloatLitExpr(@$, $1); }
         | LIT_STR                                   { $$ = new ast::StringLitExpr(@$, $1); }
+        | TRUE                                      { $$ = new ast::BoolLitExpr(@$, true); }
+        | FALSE                                     { $$ = new ast::BoolLitExpr(@$, false); }
         | MINUS expr %prec UMINUS                   { $$ = new ast::UnaryExpr(@$, $2, "-"); }
+        | NOT expr %prec NOT                        { $$ = new ast::UnaryExpr(@$, $2, "not"); }
         | LBRACKET expr_seq RBRACKET                { $$ = new ast::ArrayExpr(@$, $2);}
         | expr LBRACKET expr RBRACKET %prec ARRAY_DEREF { $$ = new ast::ArrayDerefExpr(@$, $1, $3); }
         | expr AND expr                             { $$ = new ast::BinOpExpr(@$, $1, $3, "and"); }

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -81,6 +81,14 @@ struct FloatLitExpr : public LiteralExpr {
     void accept(ASTVisitor& visitor) override;
 };
 
+struct BoolLitExpr : public Expr {
+    bool value;
+
+    BoolLitExpr(const monkey::location& loc, bool value) : Expr(loc), value(value) {}
+
+    void accept(ASTVisitor& visitor) override;
+};
+
 struct StringLitExpr : public LiteralExpr {
     using LiteralExpr::LiteralExpr;
 
@@ -155,6 +163,19 @@ struct LetExpr : public Expr {
     LetExpr(const monkey::location& loc, std::string ident, Expr* value)
         : Expr(loc), ident(std::move(ident)), value(value) {}
     LetExpr(const monkey::location& loc, std::string ident, std::unique_ptr<Expr> value)
+        : Expr(loc), ident(std::move(ident)), value(std::move(value)) {}
+    void accept(ASTVisitor& visitor) override;
+};
+
+// Reassigns an existing variable (must already be declared with let).
+// Static typing: the new value's type must match the original.
+struct AssignExpr : public Expr {
+    std::string ident;
+    std::unique_ptr<Expr> value;
+
+    AssignExpr(const monkey::location& loc, std::string ident, Expr* value)
+        : Expr(loc), ident(std::move(ident)), value(value) {}
+    AssignExpr(const monkey::location& loc, std::string ident, std::unique_ptr<Expr> value)
         : Expr(loc), ident(std::move(ident)), value(std::move(value)) {}
     void accept(ASTVisitor& visitor) override;
 };
@@ -254,6 +275,21 @@ struct ReturnStmt : public Stmt {
         : Stmt(loc), value(std::move(value)) {}
 
     void accept(ASTVisitor& visitor) override;
+};
+
+struct WhileStmt : public Stmt {
+    std::unique_ptr<Expr> cond;
+    std::unique_ptr<BlockStmt> body;
+
+    WhileStmt(const monkey::location& loc, Expr* cond, BlockStmt* body)
+        : Stmt(loc), cond(cond), body(body) {}
+    WhileStmt(const monkey::location& loc, std::unique_ptr<Expr> cond, std::unique_ptr<BlockStmt> body)
+        : Stmt(loc), cond(std::move(cond)), body(std::move(body)) {}
+
+    void setIndentationLvl(int adjustment) override { body->setIndentationLvl(adjustment); }
+    void accept(ASTVisitor& visitor) override;
+
+    // TODO: add BreakStmt / ContinueStmt support once break/continue keywords are added
 };
 
 } // namespace ast

--- a/include/ast_visitor.hpp
+++ b/include/ast_visitor.hpp
@@ -7,6 +7,7 @@ namespace ast {
 // Forward declarations
 struct IntLitExpr;
 struct FloatLitExpr;
+struct BoolLitExpr;
 struct StringLitExpr;
 struct IdentExpr;
 struct UnaryExpr;
@@ -14,10 +15,12 @@ struct BinOpExpr;
 struct ArrayExpr;
 struct ArrayDerefExpr;
 struct LetExpr;
+struct AssignExpr;
 struct ExprSeq;
 struct ExprStmt;
 struct BlockStmt;
 struct IfStmt;
+struct WhileStmt;
 struct StmtList;
 struct FnLitExpr;
 struct CallExpr;
@@ -30,6 +33,7 @@ struct ASTVisitor {
     // Expressions
     virtual void visit(IntLitExpr& node) = 0;
     virtual void visit(FloatLitExpr& node) = 0;
+    virtual void visit(BoolLitExpr& node) = 0;
     virtual void visit(StringLitExpr& node) = 0;
     virtual void visit(IdentExpr& node) = 0;
     virtual void visit(UnaryExpr& node) = 0;
@@ -37,6 +41,7 @@ struct ASTVisitor {
     virtual void visit(ArrayExpr& node) = 0;
     virtual void visit(ArrayDerefExpr& node) = 0;
     virtual void visit(LetExpr& node) = 0;
+    virtual void visit(AssignExpr& node) = 0;
     virtual void visit(ExprSeq& node) = 0;
     virtual void visit(FnLitExpr& node) = 0;
     virtual void visit(CallExpr& node) = 0;
@@ -45,6 +50,7 @@ struct ASTVisitor {
     virtual void visit(ExprStmt& node) = 0;
     virtual void visit(BlockStmt& node) = 0;
     virtual void visit(IfStmt& node) = 0;
+    virtual void visit(WhileStmt& node) = 0;
     virtual void visit(StmtList& node) = 0;
     virtual void visit(ReturnStmt& node) = 0;
 };

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "value.hpp"
+#include "type_table.hpp"
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -12,6 +13,27 @@ public:
     explicit Context(std::shared_ptr<Context> parent = nullptr) : parent_(std::move(parent)) {}
 
     void set(const std::string& name, const Value& value) { bindings_[name] = value; }
+
+    // Reassign an existing variable in the nearest enclosing scope that owns it.
+    // Enforces static typing: the new value must match the original declared type.
+    void update(const std::string& name, const Value& value) {
+        auto it = bindings_.find(name);
+        if (it != bindings_.end()) {
+            if (it->second.typeId() != value.typeId()) {
+                throw std::runtime_error(
+                    "Type mismatch in assignment to '" + name + "': "
+                    "cannot assign " + TypeTable::instance().getTypeName(value.typeId()) +
+                    " to variable of type " + TypeTable::instance().getTypeName(it->second.typeId()));
+            }
+            it->second = value;
+            return;
+        }
+        if (parent_) {
+            parent_->update(name, value);
+            return;
+        }
+        throw std::runtime_error("Undefined variable: " + name);
+    }
 
     Value get(const std::string& name) const {
         auto it = bindings_.find(name);

--- a/include/interpreter.hpp
+++ b/include/interpreter.hpp
@@ -26,6 +26,7 @@ public:
 
     void visit(ast::IntLitExpr& node) override;
     void visit(ast::FloatLitExpr& node) override;
+    void visit(ast::BoolLitExpr& node) override;
     void visit(ast::StringLitExpr& node) override;
     void visit(ast::IdentExpr& node) override;
     void visit(ast::UnaryExpr& node) override;
@@ -33,10 +34,12 @@ public:
     void visit(ast::ArrayExpr& node) override;
     void visit(ast::ArrayDerefExpr& node) override;
     void visit(ast::LetExpr& node) override;
+    void visit(ast::AssignExpr& node) override;
     void visit(ast::ExprSeq& node) override;
     void visit(ast::ExprStmt& node) override;
     void visit(ast::BlockStmt& node) override;
     void visit(ast::IfStmt& node) override;
+    void visit(ast::WhileStmt& node) override;
     void visit(ast::StmtList& node) override;
     void visit(ast::FnLitExpr& node) override;
     void visit(ast::CallExpr& node) override;

--- a/include/pretty_printer.hpp
+++ b/include/pretty_printer.hpp
@@ -17,6 +17,7 @@ public:
     // Expression visitors
     void visit(IntLitExpr& node) override;
     void visit(FloatLitExpr& node) override;
+    void visit(BoolLitExpr& node) override;
     void visit(StringLitExpr& node) override;
     void visit(IdentExpr& node) override;
     void visit(UnaryExpr& node) override;
@@ -24,12 +25,14 @@ public:
     void visit(ArrayExpr& node) override;
     void visit(ArrayDerefExpr& node) override;
     void visit(LetExpr& node) override;
+    void visit(AssignExpr& node) override;
     void visit(ExprSeq& node) override;
 
     // Statement visitors
     void visit(ExprStmt& node) override;
     void visit(BlockStmt& node) override;
     void visit(IfStmt& node) override;
+    void visit(WhileStmt& node) override;
     void visit(StmtList& node) override;
     void visit(ReturnStmt& node) override;
 

--- a/lexer.l
+++ b/lexer.l
@@ -53,6 +53,7 @@ identifier      ([[:alpha:]][[:alnum:]_]*)
 "let"           { return Parser::token::LET; }
 "fn"            { return Parser::token::FUNCTION; }
 "for"           { return Parser::token::FOR; }
+"while"         { return Parser::token::WHILE; }
 "return"        { return Parser::token::RETURN; }
 "if"            { return Parser::token::IF; }
 "else"          { return Parser::token::ELSE; }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -10,6 +10,9 @@ void IntLitExpr::accept(ASTVisitor& visitor) {
 void FloatLitExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
+void BoolLitExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
 void StringLitExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
@@ -29,6 +32,9 @@ void ArrayDerefExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 void LetExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+void AssignExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 void ExprSeq::accept(ASTVisitor& visitor) {
@@ -53,6 +59,9 @@ void CallExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 void ReturnStmt::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+void WhileStmt::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -3,6 +3,13 @@
 #include <stdexcept>
 #include <string_view>
 
+// TODO: Closures — capture the lexical scope (ctx_) at fn definition time instead of global_ctx_
+// TODO: Built-in functions — puts(x), len(arr), push(arr, val), first(arr), last(arr), rest(arr)
+// TODO: Hash literals — {key: val} syntax; requires HashObject + disambiguation from block { }
+// TODO: String concatenation — "a" + "b" via + operator on StringObject
+// TODO: for loop — for x in arr { } once iterator/range semantics are designed
+// TODO: break / continue — requires BreakException / ContinueException similar to ReturnException
+
 namespace eval {
 
 Value Interpreter::evaluate(ast::Expr& expr) {
@@ -18,6 +25,10 @@ void Interpreter::visit(ast::IntLitExpr& node) {
 
 void Interpreter::visit(ast::FloatLitExpr& node) {
     result_ = Value(std::stod(node.literal));
+}
+
+void Interpreter::visit(ast::BoolLitExpr& node) {
+    result_ = Value(node.value);
 }
 
 void Interpreter::visit(ast::StringLitExpr& node) {
@@ -44,6 +55,8 @@ void Interpreter::visit(ast::UnaryExpr& node) {
         } else {
             throw std::runtime_error("Cannot negate non-numeric value");
         }
+    } else if (op == "not") {
+        result_ = Value(!operand.isTruthy());
     } else {
         throw std::runtime_error(std::string("Unknown unary operator: ") + node.prefix);
     }
@@ -212,6 +225,12 @@ void Interpreter::visit(ast::LetExpr& node) {
     result_ = val;
 }
 
+void Interpreter::visit(ast::AssignExpr& node) {
+    Value val = evaluate(*node.value);
+    ctx_->update(node.ident, val); // walks scope chain; enforces type consistency
+    result_ = val;
+}
+
 void Interpreter::visit(ast::ExprSeq& node) {
     result_ = Value();
     for (auto& expr : node.exprs) {
@@ -259,6 +278,17 @@ void Interpreter::visit(ast::IfStmt& node) {
     }
 
     result_ = Value();
+}
+
+void Interpreter::visit(ast::WhileStmt& node) {
+    result_ = Value();
+    while (true) {
+        Value cond = evaluate(*node.cond);
+        if (!cond.isTruthy()) break;
+        // Execute body in a new scope each iteration so loop-local lets don't leak
+        node.body->accept(*this);
+        // ReturnException propagates naturally up to the enclosing function
+    }
 }
 
 // --- Functions ---

--- a/src/pretty_printer.cpp
+++ b/src/pretty_printer.cpp
@@ -12,6 +12,10 @@ void PrettyPrinter::visit(FloatLitExpr& node) {
     output_ << "(" << node.literal << ")";
 }
 
+void PrettyPrinter::visit(BoolLitExpr& node) {
+    output_ << (node.value ? "true" : "false");
+}
+
 void PrettyPrinter::visit(StringLitExpr& node) {
     output_ << "@" << node.loc << ">>\"" << node.literal << "\"";
 }
@@ -57,6 +61,11 @@ void PrettyPrinter::visit(ArrayDerefExpr& node) {
 
 void PrettyPrinter::visit(LetExpr& node) {
     output_ << "let " << node.ident << " = ";
+    node.value->accept(*this);
+}
+
+void PrettyPrinter::visit(AssignExpr& node) {
+    output_ << node.ident << " = ";
     node.value->accept(*this);
 }
 
@@ -130,6 +139,14 @@ void PrettyPrinter::visit(ReturnStmt& node) {
     output_ << "return ";
     node.value->accept(*this);
     output_ << ";";
+}
+
+void PrettyPrinter::visit(WhileStmt& node) {
+    std::string indent(node.nested_lvl, '\t');
+    output_ << indent << "while ";
+    node.cond->accept(*this);
+    output_ << "\n";
+    node.body->accept(*this);
 }
 
 } // namespace ast

--- a/tests/test_interpreter.cpp
+++ b/tests/test_interpreter.cpp
@@ -605,3 +605,173 @@ TEST_CASE("Interpreter: different function signatures have different type ids", 
     auto val2 = interpret("let g = fn(x float) int { 1; }; g(1.0); g;");
     CHECK(val1.typeId() != val2.typeId());
 }
+
+// --- not operator ---
+
+TEST_CASE("Interpreter: not true is false", "[interpreter][not]") {
+    auto val = interpret("not true;");
+    REQUIRE(val.isBool());
+    CHECK(val.asBool() == false);
+}
+
+TEST_CASE("Interpreter: not false is true", "[interpreter][not]") {
+    auto val = interpret("not false;");
+    REQUIRE(val.isBool());
+    CHECK(val.asBool() == true);
+}
+
+TEST_CASE("Interpreter: not zero is true", "[interpreter][not]") {
+    auto val = interpret("not 0;");
+    REQUIRE(val.isBool());
+    CHECK(val.asBool() == true);
+}
+
+TEST_CASE("Interpreter: not non-zero is false", "[interpreter][not]") {
+    auto val = interpret("not 42;");
+    REQUIRE(val.isBool());
+    CHECK(val.asBool() == false);
+}
+
+TEST_CASE("Interpreter: not in conditional", "[interpreter][not]") {
+    auto val = interpret("let x = false; if not x { 1; } else { 2; }");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 1);
+}
+
+TEST_CASE("Interpreter: double not", "[interpreter][not]") {
+    auto val = interpret("not not true;");
+    REQUIRE(val.isBool());
+    CHECK(val.asBool() == true);
+}
+
+// --- Variable reassignment ---
+
+TEST_CASE("Interpreter: reassignment updates value", "[interpreter][assign]") {
+    auto val = interpret("let x = 1; x = 2; x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 2);
+}
+
+TEST_CASE("Interpreter: reassignment result is new value", "[interpreter][assign]") {
+    auto val = interpret("let x = 10; x = 99;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 99);
+}
+
+TEST_CASE("Interpreter: reassignment to undefined variable throws", "[interpreter][assign]") {
+    REQUIRE_THROWS_AS(interpret("y = 5;"), std::runtime_error);
+}
+
+TEST_CASE("Interpreter: reassignment type mismatch throws", "[interpreter][assign]") {
+    REQUIRE_THROWS_AS(interpret("let x = 1; x = 1.5;"), std::runtime_error);
+}
+
+TEST_CASE("Interpreter: reassignment in inner scope mutates outer variable", "[interpreter][assign]") {
+    // x is declared in outer scope; assignment inside block should update it
+    auto val = interpret("let x = 10; { x = 20; } x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 20);
+}
+
+TEST_CASE("Interpreter: let in inner scope shadows but does not mutate outer", "[interpreter][assign]") {
+    // let inside block creates a new binding; outer x unchanged
+    auto val = interpret("let x = 10; { let x = 20; } x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 10);
+}
+
+TEST_CASE("Interpreter: multiple reassignments accumulate", "[interpreter][assign]") {
+    auto val = interpret("let x = 0; x = 1; x = x + 1; x = x + 1; x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 3);
+}
+
+// --- While loop ---
+
+TEST_CASE("Interpreter: while loop body not executed when condition is false", "[interpreter][while]") {
+    auto val = interpret("let x = 0; while false { x = 1; } x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 0);
+}
+
+TEST_CASE("Interpreter: while loop counts up", "[interpreter][while]") {
+    auto val = interpret("let i = 0; while i < 5 { i = i + 1; } i;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 5);
+}
+
+TEST_CASE("Interpreter: while loop accumulates sum", "[interpreter][while]") {
+    // sum = 0+1+2+3+4 = 10
+    auto val = interpret(
+        "let i = 0;"
+        "let sum = 0;"
+        "while i < 5 { sum = sum + i; i = i + 1; }"
+        "sum;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 10);
+}
+
+TEST_CASE("Interpreter: while loop with local variable does not leak to outer scope", "[interpreter][while]") {
+    // 'tmp' is declared inside the loop body; must not be visible after loop
+    auto val = interpret(
+        "let i = 0;"
+        "while i < 3 { let tmp = i * 2; i = i + 1; }"
+        "i;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 3);
+    REQUIRE_THROWS_AS(interpret(
+        "let i = 0;"
+        "while i < 3 { let tmp = i * 2; i = i + 1; }"
+        "tmp;"),
+        std::runtime_error);
+}
+
+TEST_CASE("Interpreter: while loop mutates outer variable from inside block", "[interpreter][while]") {
+    // Verifies reassignment (=) reaches through block scope to outer variable
+    auto val = interpret(
+        "let counter = 0;"
+        "while counter < 10 { counter = counter + 1; }"
+        "counter;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 10);
+}
+
+TEST_CASE("Interpreter: nested while loops", "[interpreter][while]") {
+    // 3x3 = 9 iterations, outer * inner both count
+    auto val = interpret(
+        "let i = 0;"
+        "let total = 0;"
+        "while i < 3 {"
+        "  let j = 0;"
+        "  while j < 3 { total = total + 1; j = j + 1; }"
+        "  i = i + 1;"
+        "}"
+        "total;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 9);
+}
+
+TEST_CASE("Interpreter: while loop with not condition", "[interpreter][while]") {
+    auto val = interpret(
+        "let done = false;"
+        "let x = 0;"
+        "while not done { x = x + 1; if x >= 3 { done = true; } }"
+        "x;");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 3);
+}
+
+TEST_CASE("Interpreter: while loop inside function with return", "[interpreter][while]") {
+    auto val = interpret(
+        "let findFirst = fn(target int) int {"
+        "  let i = 0;"
+        "  while i < 10 {"
+        "    if i == target { return i; }"
+        "    i = i + 1;"
+        "  }"
+        "  return -1;"
+        "};"
+        "findFirst(7);");
+    REQUIRE(val.isInt());
+    CHECK(val.asInt() == 7);
+}


### PR DESCRIPTION
- Add 'not' unary operator (NOT token already existed, now wired in grammar + interpreter)
- Add BoolLitExpr AST node so 'true'/'false' are first-class expressions
- Add AssignExpr AST node for variable reassignment (Ident = expr)
  - Context::update() walks scope chain and enforces static type consistency
- Add WhileStmt AST node and 'while expr block_stmt' grammar rule
  - Loop body executes in a new scope per iteration (block-local lets don't leak)
  - ReturnException propagates naturally through while loops
- Document TODO features in interpreter.cpp: closures, builtins, hash literals, string concat, for loop, break/continue
- All 119 tests pass (added 28 new test cases for not/assign/while)